### PR TITLE
Issue #99 fixed

### DIFF
--- a/scenes/maps/main_map/main_map.tscn
+++ b/scenes/maps/main_map/main_map.tscn
@@ -1061,6 +1061,8 @@ shape = SubResource("RectangleShape2D_apqsq")
 [node name="Players" type="Node2D" parent="."]
 y_sort_enabled = true
 
+[node name="DeadBodies" type="Node2D" parent="."]
+
 [node name="Camera" type="Camera2D" parent="."]
 enabled = false
 zoom = Vector2(0.45, 0.45)

--- a/scenes/player/assets/dead_body.gd
+++ b/scenes/player/assets/dead_body.gd
@@ -16,6 +16,6 @@ func set_dead_player(victim: int) -> void:
 	sprite.modulate = Color(0, 0.275, 1)
 	sprite.rotation = PI/2 - PI/12
 	
-	node.global_position = get_parent().get_node(str(victim)).global_position
+	node.global_position = get_parent().get_parent().get_node("Players/"+str(victim)).global_position
 	label.size.x = 600
 	label.position = Vector2(-label.size.x / 2,-100)

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -302,7 +302,7 @@ func _on_killed_player(player_id: int, is_victim: bool) -> void:
 
 		if is_victim:
 			var dead_body = preload("res://scenes/player/assets/dead_body.tscn").instantiate()
-			get_parent().add_child(dead_body)
+			get_parent().get_parent().get_node("DeadBodies").add_child(dead_body)
 			dead_body.set_dead_player(player_id)
 			dead_body.get_node("DeadBodyLabel").text = "Oblany student (" + GameManager.get_registered_player_key(player_id, "username") + ")"
 


### PR DESCRIPTION
# Pull Request: Bugfix/Issue#99 into Main 🐞

### Issue Resolved
Fixes the issue where players could instantiate bodies from spirits.

### Problem Description
The issue occurred when two players were killed in the same location, allowing the instantiation of new bodies from dead players. This led to unexpected behavior, as these new bodies retained player logic and could be killed.

### Solution
Created a `DeadBodies` `Node2D` to handle the instantiation and management of dead player bodies. This ensures proper separation of logic between live players and their deceased counterparts.

### Testing
Manually tested the fix by reproducing the scenario described in the issue. Verified that new dead bodies are now correctly instantiated and isolated from player logic.

### Checklist
- [x] Tested locally
- [ ] Code reviewed
- [x] Issue referenced in the commit message

