### PR TITLE
Bugfix/issue#123

### DIFF
--- a/scenes/ui/chat/chat.gd
+++ b/scenes/ui/chat/chat.gd
@@ -17,27 +17,46 @@ const FADE_OUT_TIME = 0.25
 @onready var chat_logs_container = $%ChatLogsContainer
 @onready var chat_logs_scrollbar = chat_logs_scroll_container.get_v_scroll_bar()
 @onready var username = GameManager.get_current_player_key("username")
+@onready var group_label = $%Group
 
 var message_scene = preload("res://scenes/ui/chat/message/message.tscn")
 var system_message_scene = preload("res://scenes/ui/chat/system_message/system_message.tscn")
 
 var last_known_scroll_max = 0
-var current_group = Group.LECTURER
+var current_group = Group.GLOBAL
 var fade_out_tween 
 
 
 func _ready():
 	chat_logs_scrollbar.changed.connect(_update_scrollbar_position)
 	input_text.hide()
+	group_label.hide()
+
+	_update_group_label()
 
 
 func _input(event):
 	if event.is_action_pressed("chat_open") && !input_text.visible:
 		_open_chat()
 		get_viewport().set_input_as_handled()
-	if (event.is_action_pressed("chat_close") || event.is_action_pressed("pause_menu")) && input_text.visible:
+	if event.is_action_pressed("chat_close") && input_text.visible:
+		_switch_chat_group()
+		get_viewport().set_input_as_handled()
+	if event.is_action_pressed("pause_menu") && input_text.visible:
 		_close_chat()
 		get_viewport().set_input_as_handled()
+
+
+func _switch_chat_group():
+	if GameManager.get_current_player_key("is_lecturer"):
+		current_group = Group.LECTURER if current_group == Group.GLOBAL else Group.GLOBAL
+		_update_group_label()
+
+func _update_group_label():
+	if GameManager.get_current_player_key("is_lecturer"):
+		group_label.text = "Lecturer" if current_group == Group.LECTURER else "Global"
+	else:
+		group_label.text = "Dead" if current_group == Group.DEAD else "Global"
 
 
 @rpc("any_peer", "call_local", "reliable")
@@ -49,8 +68,6 @@ func send_message(message, group, id):
 		Group.LECTURER:
 			if current_group == Group.LECTURER:
 				_create_message(GameManager.get_registered_players()[id], message, Group.LECTURER)
-			else:
-				_create_message(GameManager.get_registered_players()[id], message, Group.GLOBAL)
 		Group.SYSTEM:
 			var system_message_instance = system_message_scene.instantiate()
 			chat_logs_container.add_child(system_message_instance)
@@ -62,7 +79,7 @@ func send_message(message, group, id):
 
 			timer.start()
 		_:
-			_create_message(GameManager.get_registered_players()[id], message, current_group)
+			_create_message(GameManager.get_registered_players()[id], message, Group.GLOBAL)
 	
 	if multiplayer.is_server():
 		for peer_id in GameManager.get_registered_players().keys():
@@ -121,12 +138,14 @@ func _update_scrollbar_position():
 func _open_chat():
 	input_text.grab_focus()
 	input_text.show()
+	group_label.show()
 	chat_logs_scroll_container.modulate.a = 1
 
 
 func _close_chat():
 	input_text.release_focus()
 	input_text.hide()
+	group_label.hide()
 	input_text.text = ""
 
 	if get_parent().name == "VotingScreen":

--- a/scenes/ui/chat/chat.tscn
+++ b/scenes/ui/chat/chat.tscn
@@ -41,6 +41,11 @@ unique_name_in_owner = true
 wait_time = 3.464
 one_shot = true
 
+[node name="Group" type="Label" parent="ChatContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "[group]"
+
 [node name="InputText" type="LineEdit" parent="ChatContainer"]
 unique_name_in_owner = true
 layout_mode = 2

--- a/scenes/ui/chat/chat.tscn
+++ b/scenes/ui/chat/chat.tscn
@@ -16,7 +16,7 @@ offset_bottom = -24.0
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
-theme_override_constants/separation = 20
+theme_override_constants/separation = 5
 
 [node name="ChatLogsScrollbar" type="ScrollContainer" parent="ChatContainer"]
 unique_name_in_owner = true


### PR DESCRIPTION
Naprawia działanie grup na czacie:

- Każdy gracz ma na starcie "Global'
- Wykładowca może zmieniać pomiędzy "Lecturer", a "Global"
- - Wiadomości wysłane na grupie "Lecturer" są tylko widoczne dla wykładowców i martwych
- - Martwi gracze mogą porozumiewać się tylko pomiędzy sobą, ale widzą wszystkie wiadomości (Global, Lecturer)