### PR TITLE
Ekran Głosowania Błędy

### DIFF
--- a/scenes/maps/lobby/scenes/lobby_ui/lobby_ui.gd
+++ b/scenes/maps/lobby/scenes/lobby_ui/lobby_ui.gd
@@ -72,7 +72,7 @@ func _on_interact_button_button_down():
 
 func _on_chat_button_button_down():
 	if get_parent().get_node("Chat").get_node("%InputText").visible:
-		execute_action("chat_close")
+		execute_action("pause_menu")
 	else:
 		execute_action("chat_open")
 

--- a/scenes/ui/chat/chat.gd
+++ b/scenes/ui/chat/chat.gd
@@ -40,6 +40,9 @@ func _input(event):
 		if GameManager.get_current_game_key("is_paused"):
 			return
 
+		if get_parent().get_parent().name == "VotingScreen":
+			_open_chat()
+
 		if input_text.visible:
 			return
 
@@ -70,12 +73,13 @@ func _switch_chat_group():
 		_update_group_label()
 
 func _update_group_label():
-	if !GameManager.get_current_player_key("is_alive"):
-		group_label.text = "Dead"
-	elif GameManager.get_current_player_key("is_lecturer"):
-		group_label.text = "Lecturer" if current_group == Group.LECTURER else "Global"
+	if !GameManager.get_current_player_key("is_dead"):
+		if GameManager.get_current_player_key("is_lecturer"):
+			group_label.text = "Wykładowcy" if current_group == Group.LECTURER else "Globalny"
+		else:
+			group_label.text = "Globalny"
 	else:
-		group_label.text = "Global"
+		group_label.text = "Martwy"
 		
 
 
@@ -163,13 +167,12 @@ func _open_chat():
 
 
 func _close_chat():
-	input_text.release_focus()
-	input_text.hide()
-	group_label.hide()
 	input_text.text = ""
-
+	input_text.release_focus()
 	if get_parent().get_parent().name == "VotingScreen":
 		return
-
+	input_text.hide()
+	group_label.hide()
+	
 	timer.start()
 	

--- a/scenes/ui/chat/chat.gd
+++ b/scenes/ui/chat/chat.gd
@@ -32,6 +32,9 @@ func _ready():
 	input_text.hide()
 	group_label.hide()
 
+	if GameManager.get_current_player_key("is_dead"):
+		current_group = Group.DEAD
+
 	_update_group_label()
 
 
@@ -90,7 +93,7 @@ func send_message(message, group, id):
 			if current_group == Group.DEAD:
 				_create_message(GameManager.get_registered_players()[id], message, Group.DEAD)
 		Group.LECTURER:
-			if current_group == Group.LECTURER:
+			if current_group == Group.LECTURER or current_group == Group.DEAD:
 				_create_message(GameManager.get_registered_players()[id], message, Group.LECTURER)
 		Group.SYSTEM:
 			var system_message_instance = system_message_scene.instantiate()

--- a/scenes/ui/voting_screen/player_box/player_box.tscn
+++ b/scenes/ui/voting_screen/player_box/player_box.tscn
@@ -98,12 +98,12 @@ fit_content = true
 [node name="DecisionYes" type="Button" parent="VBoxContainer/Decision"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "TAK"
+text = "Tak"
 
 [node name="DecisionNo" type="Button" parent="VBoxContainer/Decision"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "NIE"
+text = "Nie"
 
 [connection signal="pressed" from="VBoxContainer/Panel/Button" to="." method="_on_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/Decision/DecisionYes" to="." method="_on_decision_yes_pressed"]

--- a/scenes/ui/voting_screen/voting_screen.gd
+++ b/scenes/ui/voting_screen/voting_screen.gd
@@ -164,7 +164,7 @@ func _on_end_voting_timer_timeout():
 
 		GameManager.set_most_voted_player.rpc(GameManager.get_registered_players()[most_voted_player_id] if most_voted_player_id != null else null)
 
-		#GameManager.kill_player(most_voted_player_id)
+		GameManager.kill_player(most_voted_player_id)
 
 
 ## Zmienia scene na ekran wyrzucenia

--- a/scenes/ui/voting_screen/voting_screen.gd
+++ b/scenes/ui/voting_screen/voting_screen.gd
@@ -24,6 +24,8 @@ var time = 0
 
 var is_selected = false
 
+var is_voting_ended = false
+
 ## Określa czy czat jest otwarty
 var is_chat_open:bool = false
 
@@ -82,6 +84,11 @@ func start_voting():
 
 
 func _process(delta):
+	if not is_voting_ended:
+		_count_time(delta)
+
+
+func _count_time(delta):
 	if time < DISCUSSION_TIME:
 		time += delta
 		var time_remaining = DISCUSSION_TIME - time
@@ -90,7 +97,6 @@ func _process(delta):
 		time += delta
 		var time_remaining = DISCUSSION_TIME + VOTING_TIME - time
 		end_vote_text.text = "Głosowanie kończy się za %02d sekund" % time_remaining
-
 
 func _on_player_voted(voted_player_key):
 	skip_button.disabled = true
@@ -185,9 +191,9 @@ func _render_player_boxes():
 		new_player_box.init(i, votes[i] if i in votes else [])
 		new_player_box.connect("player_voted", _on_player_voted)
 
-
-## Zamyka głosowanie
+@rpc("any_peer", "call_local", "reliable")
 func _on_end_voting_timer_timeout():
+	is_voting_ended = true
 	GameManager.set_current_game_key("is_voted", true)
 
 	end_vote_text.text = "[center]Głosowanie zakończone![/center]"

--- a/scenes/ui/voting_screen/voting_screen.gd
+++ b/scenes/ui/voting_screen/voting_screen.gd
@@ -225,7 +225,12 @@ func on_interface_scale_changed(value:float):
 
 
 func _on_discussion_timer_timeout():
-	skip_button.disabled = false
 	voting_timer.start(VOTING_TIME)
+
+	if GameManager.get_current_player_key("is_dead"):
+		return
+
+	skip_button.disabled = false
+
 	for player in players.get_children():
 		player.set_voting_status(true)

--- a/scenes/ui/voting_screen/voting_screen.tscn
+++ b/scenes/ui/voting_screen/voting_screen.tscn
@@ -113,7 +113,7 @@ grow_vertical = 0
 [node name="SkipButton" type="Button" parent="Background/SkipDecision"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "POMIŃ GŁOS"
+text = "Pomiń Głos"
 
 [node name="Decision" type="HBoxContainer" parent="Background/SkipDecision"]
 unique_name_in_owner = true
@@ -124,18 +124,18 @@ theme_override_constants/separation = 10
 [node name="DecisionText" type="RichTextLabel" parent="Background/SkipDecision/Decision"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "Is this your final vote?"
+text = "Jesteś pewny?"
 fit_content = true
 
 [node name="DecisionYes" type="Button" parent="Background/SkipDecision/Decision"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "YES"
+text = "Tak"
 
 [node name="DecisionNo" type="Button" parent="Background/SkipDecision/Decision"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "NO"
+text = "Nie"
 
 [node name="GridContainer" type="GridContainer" parent="."]
 layout_mode = 1

--- a/scenes/ui/voting_screen/voting_screen.tscn
+++ b/scenes/ui/voting_screen/voting_screen.tscn
@@ -12,7 +12,6 @@ border_width_top = 10
 border_width_right = 10
 border_width_bottom = 10
 border_color = Color(0, 0, 0, 1)
-border_blend = true
 
 [node name="VotingScreen" type="Control"]
 layout_mode = 3

--- a/scenes/ui/voting_screen/voting_screen.tscn
+++ b/scenes/ui/voting_screen/voting_screen.tscn
@@ -1,9 +1,18 @@
-[gd_scene load_steps=5 format=3 uid="uid://dfdk7562ehhtp"]
+[gd_scene load_steps=6 format=3 uid="uid://dfdk7562ehhtp"]
 
 [ext_resource type="Script" path="res://scenes/ui/voting_screen/voting_screen.gd" id="1_kta77"]
 [ext_resource type="PackedScene" uid="uid://c243bu478e0su" path="res://scenes/ui/chat/chat.tscn" id="2_u4dx5"]
 [ext_resource type="Texture2D" uid="uid://x3hb3b3rrfa1" path="res://scenes/maps/lobby/scenes/lobby_ui/assets/czat.png" id="3_vad85"]
 [ext_resource type="Texture2D" uid="uid://c3krnig4q8qwh" path="res://scenes/ui/user_interface/assets/__nowy_setting_v1.png" id="4_k0mfc"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_d8hpk"]
+bg_color = Color(0.14902, 0.14902, 0.14902, 1)
+border_width_left = 10
+border_width_top = 10
+border_width_right = 10
+border_width_bottom = 10
+border_color = Color(0, 0, 0, 1)
+border_blend = true
 
 [node name="VotingScreen" type="Control"]
 layout_mode = 3
@@ -14,34 +23,6 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_kta77")
 metadata/_edit_use_anchors_ = true
-
-[node name="ChatContainer" type="Control" parent="."]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-
-[node name="Chat" parent="ChatContainer" instance=ExtResource("2_u4dx5")]
-unique_name_in_owner = true
-layer = 2
-
-[node name="ChatBackground" type="ColorRect" parent="ChatContainer"]
-unique_name_in_owner = true
-z_index = 1
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 136.0
-offset_right = -149.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-color = Color(0.14902, 0.14902, 0.14902, 1)
 
 [node name="Background" type="ColorRect" parent="."]
 layout_mode = 1
@@ -124,7 +105,7 @@ theme_override_constants/separation = 10
 [node name="DecisionText" type="RichTextLabel" parent="Background/SkipDecision/Decision"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "Jesteś pewien?"
+text = "Jesteś pewny?"
 fit_content = true
 
 [node name="DecisionYes" type="Button" parent="Background/SkipDecision/Decision"]
@@ -159,6 +140,34 @@ texture_normal = ExtResource("3_vad85")
 [node name="PauseMenuButton" type="TextureButton" parent="GridContainer"]
 layout_mode = 2
 texture_normal = ExtResource("4_k0mfc")
+
+[node name="ChatContainer" type="Control" parent="."]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="Chat" parent="ChatContainer" instance=ExtResource("2_u4dx5")]
+unique_name_in_owner = true
+layer = 2
+
+[node name="ChatBackground" type="Panel" parent="ChatContainer"]
+unique_name_in_owner = true
+z_index = 1
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 136.0
+offset_right = -149.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_d8hpk")
 
 [connection signal="pressed" from="Background/SkipDecision/SkipButton" to="." method="_on_skip_button_pressed"]
 [connection signal="pressed" from="Background/SkipDecision/Decision/DecisionYes" to="." method="_on_decision_yes_pressed"]


### PR DESCRIPTION
Naprawia issue #174 
Naprawia issue #176 

Po części naprawia #175:
input_text jest teraz cały czas widoczny, ale nie wiem czemu nie mogę kompletnie kliknąć w to, żeby zacząć pisać, "t" już działa 
(pomocy)

Dodaje border do tła czatu w ekranie głosowania

Podłączono metodę pod sygnał player_deregistered, która, gdy gracz wyjdzie to renderuje od nowa boxy z graczami w ekranie głosowania i liczy głosy (oczywiście nie przetestuję, bo jest błąd poniżej (jak testowałem bez tej metody to błąd ten sam))

A i nie wiem czemu crashuje po wyjściu podczas głosowania lub dyskusji, choć nic nie zmieniałem, może mam coś z branchem nie tak, na mainie działa
![image](https://github.com/wzimongus/wzimongus/assets/50219130/f5f167fe-3125-453e-b8ff-003767a94efd)
![image](https://github.com/wzimongus/wzimongus/assets/50219130/9e3ee2a3-4a5d-4ab4-9c2e-4fc254976554)
