### PR TITLE
Bugfix: Fix bug that made camera light visible by player

### DIFF
--- a/scenes/maps/main_map/scenes/camera/camera.gd
+++ b/scenes/maps/main_map/scenes/camera/camera.gd
@@ -10,4 +10,11 @@ func _ready():
 
 ## Zmienia widoczność światła kamery aby widać było stojących w jej polu widzenia graczy
 func change_light_visibility():
+	if $Light.visible:
+		$Light.visible = !$Light.visible
+	else:
+		$LightTimer.start()
+
+
+func _on_light_timer_timeout():
 	$Light.visible = !$Light.visible

--- a/scenes/maps/main_map/scenes/camera/camera.tscn
+++ b/scenes/maps/main_map/scenes/camera/camera.tscn
@@ -24,3 +24,9 @@ shadow_color = Color(1, 1, 1, 0)
 texture = ExtResource("2_7lg6c")
 texture_scale = 7.0
 height = 10.0
+
+[node name="LightTimer" type="Timer" parent="."]
+wait_time = 0.25
+one_shot = true
+
+[connection signal="timeout" from="LightTimer" to="." method="_on_light_timer_timeout"]


### PR DESCRIPTION
Fixed the problem that light used by the camera system to show people outside of the player's field of view could be seen by the player during the window's animation.
Added timer set to 0.25 seconds that postpones activation of camera lights until after the window is fully up