### PR TITLE
Feature: Put the last interaction point in their place

### DIFF
--- a/scenes/game/maps/lobby/lobby.tscn
+++ b/scenes/game/maps/lobby/lobby.tscn
@@ -93,6 +93,7 @@ offset = Vector2(0, -100)
 position = Vector2(191, 1042)
 
 [node name="Kamien" type="Sprite2D" parent="Objects/Kamien"]
+visible = false
 position = Vector2(0, -350)
 scale = Vector2(1.122, 1.055)
 texture = ExtResource("4_364p8")
@@ -100,11 +101,8 @@ texture = ExtResource("4_364p8")
 [node name="StaticBody2D" type="StaticBody2D" parent="Objects/Kamien"]
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Objects/Kamien/StaticBody2D"]
+position = Vector2(-15, 0)
 polygon = PackedVector2Array(-177, -4, -328, 73, 327, 74, 178, -5)
-
-[node name="SkinSelectorPoint" parent="." instance=ExtResource("3_xxsdp")]
-z_index = 4
-position = Vector2(147, -276)
 
 [node name="SpawnPoints" type="Node2D" parent="."]
 
@@ -137,6 +135,11 @@ position = Vector2(1050, 2.08165e-12)
 
 [node name="9" type="Node2D" parent="SpawnPoints"]
 position = Vector2(1350, 2.08165e-12)
+
+[node name="SkinSelectorPoint" parent="." instance=ExtResource("3_xxsdp")]
+z_index = 5
+y_sort_enabled = true
+position = Vector2(191, 1042)
 
 [node name="Players" type="Node2D" parent="."]
 y_sort_enabled = true

--- a/scenes/game/maps/lobby/skin_selector_point/skin_selector_point.gd
+++ b/scenes/game/maps/lobby/skin_selector_point/skin_selector_point.gd
@@ -22,8 +22,6 @@ signal use_button_active(is_active: bool)
 
 
 func _ready():
-	_sprite_node.texture = _sprite
-	_sprite_node.scale = Vector2(_scale_factor, _scale_factor)
 	_sprite_node.material = _sprite_node.material.duplicate()
 	_sprite_node.material.set_shader_parameter("line_color", _out_of_range_color)
 	_sprite_node.material.set_shader_parameter("line_thickness", _line_thickness)

--- a/scenes/game/maps/lobby/skin_selector_point/skin_selector_point.tscn
+++ b/scenes/game/maps/lobby/skin_selector_point/skin_selector_point.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://clyynf7f5bwqv"]
+[gd_scene load_steps=6 format=3 uid="uid://clyynf7f5bwqv"]
 
 [ext_resource type="Script" path="res://scenes/game/maps/lobby/skin_selector_point/skin_selector_point.gd" id="1_kee2m"]
 [ext_resource type="Shader" path="res://assets/shaders/outline.gdshader" id="2_1htbf"]
+[ext_resource type="Texture2D" uid="uid://ccpiiwi5tsiuw" path="res://assets/textures/lobby/objects/kamien.png" id="3_loxyp"]
 
-[sub_resource type="CircleShape2D" id="CircleShape2D_ykn66"]
-radius = 170.238
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_eohvk"]
+radius = 394.0
+height = 1054.0
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_xwbu7"]
 shader = ExtResource("2_1htbf")
@@ -18,13 +20,16 @@ collision_mask = 2
 monitorable = false
 priority = 1
 script = ExtResource("1_kee2m")
-scale_factor = null
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("CircleShape2D_ykn66")
+position = Vector2(-5, -287)
+shape = SubResource("CapsuleShape2D_eohvk")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 material = SubResource("ShaderMaterial_xwbu7")
+position = Vector2(0, -350)
+scale = Vector2(1.122, 1.055)
+texture = ExtResource("3_loxyp")
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]
 [connection signal="body_exited" from="." to="." method="_on_body_exited"]

--- a/scenes/game/maps/lobby/skin_selector_point/skin_selector_point.tscn
+++ b/scenes/game/maps/lobby/skin_selector_point/skin_selector_point.tscn
@@ -27,9 +27,10 @@ shape = SubResource("CapsuleShape2D_eohvk")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 material = SubResource("ShaderMaterial_xwbu7")
-position = Vector2(0, -350)
+position = Vector2(0, 10)
 scale = Vector2(1.122, 1.055)
 texture = ExtResource("3_loxyp")
+offset = Vector2(0, -350)
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]
 [connection signal="body_exited" from="." to="." method="_on_body_exited"]

--- a/scenes/game/maps/main_map/main_map.tscn
+++ b/scenes/game/maps/main_map/main_map.tscn
@@ -461,6 +461,7 @@ position = Vector2(4023, -1461)
 metadata/_edit_group_ = true
 
 [node name="Sprite" type="Sprite2D" parent="Objects/PokojWykladowcowBiurko"]
+visible = false
 texture = ExtResource("43_n4m3t")
 
 [node name="CollisionBox" type="StaticBody2D" parent="Objects/PokojWykladowcowBiurko"]
@@ -1039,7 +1040,8 @@ sprite = ExtResource("31_dhdh4")
 minigame_scene = ExtResource("86_ao4sp")
 
 [node name="CameraSystem" parent="InteractionPoints" instance=ExtResource("3_e0rk4")]
-position = Vector2(4016, -1329)
+position = Vector2(4023, -1461)
+sprite = ExtResource("43_n4m3t")
 is_minigame = false
 minigame_scene = ExtResource("89_58eb3")
 


### PR DESCRIPTION
No more running around the building to find the place where you can easily change your look, no more camera system without outline. These times are no longer. Today we the people take back what is rightfully ours and put those pesky Bourgeoisie interaction points in their proper place. From this day on we will change our looks with the mighty stone, like the civilized people we are, we will also light up the camera system desk with the glorious green outline that it was always meant to shine in. We are the true devs of Wzimongus and we do what shall be done. Don't ask, I just felt like writing this in this way.