### PR TITLE
Bugfix: The name of ejected player not showind up in ejection screen

### DIFF
--- a/scenes/game/maps/main_map/ejection_screen/ejection_screen.gd
+++ b/scenes/game/maps/main_map/ejection_screen/ejection_screen.gd
@@ -9,7 +9,7 @@ extends Control
 @onready var _ejection_message = %EjectionMessage
 
 ## Referencja do najczęściej głosowanego gracza
-var _most_voted_player = GameManagerSingleton.get_current_game_value("_most_voted_player")
+var _most_voted_player = GameManagerSingleton.get_current_game_value("most_voted_player")
 ## Timer do następnej rundy
 var _next_round_timer = Timer.new()
 


### PR DESCRIPTION
Fixed, just fixed, it was literally one symbol that broke it, no reason to write homes about it, it was probably added during privatization, ahh privatization, the worst, a lot of companies fell during privatization during balcerowicz's reforms, maybe they deserved it, I mean they probably wouldn't have bankrupted if they were making money before the privatization but dunno, maybe they fell because of bad management after privatization, companies that were bought by foreign investors didn't really look good for the government actually all of balcerowicz's period didn't look good for that government, there probably is a reason why they lost the next election... well dunno, weren't even born yet, wasn't supposed to write this much, as I said, easy fix not much to write about, bye.