### PR TITLE
Bugfix/issue#225

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -116,7 +116,8 @@ change_group={
 2d_physics/layer_1="static_objects"
 2d_physics/layer_2="players"
 2d_physics/layer_3="vents"
-2d_physics/layer_4="kill_radius"
+2d_physics/layer_4="dead_players"
+2d_physics/layer_5="dead_player_map_borders"
 
 [netfox]
 

--- a/scenes/characters/player/player.gd
+++ b/scenes/characters/player/player.gd
@@ -443,7 +443,7 @@ func _on_killed_player(player_id: int, is_victim: bool) -> void:
 		if GameManagerSingleton.get_current_player_id() != player_id:
 			get_parent().get_node(str(player_id)).visible = false
 
-		# Włącza widoczność wszystkich martwych graczy u marwtch graczy.
+		# Włącza widoczność wszystkich martwych graczy u martwych graczy.
 		if GameManagerSingleton.get_current_player_value("is_dead"):
 			for i in GameManagerSingleton.get_registered_players().keys():
 				get_parent().get_node(str(i)).visible = true

--- a/scenes/characters/player/player.gd
+++ b/scenes/characters/player/player.gd
@@ -288,6 +288,9 @@ func _input(event):
 
 		if !victim:
 			return
+		
+		if get_parent().get_node(str(victim)).collision_layer != 2:
+			return
 
 		$PlayerInteractionPlayer.stream = load("res://assets/audio/kill_sound.ogg")
 		$PlayerInteractionPlayer.play()

--- a/scenes/characters/player/player.tscn
+++ b/scenes/characters/player/player.tscn
@@ -221,7 +221,6 @@ z_index = 5
 y_sort_enabled = true
 position = Vector2(-1, -47)
 collision_layer = 2
-collision_mask = 9
 motion_mode = 1
 wall_min_slide_angle = 0.0349066
 safe_margin = 5.0


### PR DESCRIPTION
# Pull Request: Bugfix #225 👻

### Problem
When there's more than one impostor, spooky things happen! Bodies start materializing from spirits, but only for one sneaky impostor.

### Changes Made
Fixed #225 by implementing some ghost-busting code! Now, we check the collision layer of potential victims before allowing any supernatural body instantiation. No more ghostly shenanigans, just clean gameplay.

### Testing
Tested and verified locally to ensure the spirit world stays where it belongs.

Cheers to a ghost-free gaming experience! 🚫👻
